### PR TITLE
Evaluate epics ready-ready status after field name changes in Jira instance

### DIFF
--- a/jira/client.go
+++ b/jira/client.go
@@ -62,6 +62,8 @@ func NewClient(url string, username, password *string) (*Client, error) {
 			client.CustomFieldID.StoryPoints = f.ID
 		case "5-Acks Check":
 			client.CustomFieldID.AckFlags = f.ID
+		case "Ready-Ready":
+			client.CustomFieldID.AckFlags = f.ID
 		case "QA Contact":
 			client.CustomFieldID.QAContact = f.ID
 		case "Acceptance Criteria":
@@ -120,11 +122,13 @@ func (c *Client) FindIssues(jql string) (IssueCollection, error) {
 				storyPoints = int(val.(float64))
 			}
 
-			issueApprovals := IssueApprovals{false, false, false, false, false}
+			issueApprovals := IssueApprovals{false, false, false, false, false, false}
 
 			if val := i.Fields.Unknowns[c.CustomFieldID.AckFlags]; val != nil {
 				for _, p := range val.([]interface{}) {
 					switch p.(map[string]interface{})["value"].(string) {
+					//The Old Ones
+					//-->
 					case "devel_ack":
 						issueApprovals.Development = true
 					case "pm_ack":
@@ -135,6 +139,32 @@ func (c *Client) FindIssues(jql string) (IssueCollection, error) {
 						issueApprovals.Experience = true
 					case "doc_ack":
 						issueApprovals.Documentation = true
+					//<--
+					//The New Ones
+					//-->
+					case "dev-ack":
+						issueApprovals.Development = true
+					case "pm-ack":
+						issueApprovals.Product = true
+					case "qa-ack":
+						issueApprovals.Quality = true
+					case "ux-ack":
+						issueApprovals.Experience = true
+					case "doc-ack":
+						issueApprovals.Documentation = true
+					case "dev-ready":
+						issueApprovals.Development = true
+					case "pm-ready":
+						issueApprovals.Product = true
+					case "qa-ready":
+						issueApprovals.Quality = true
+					case "ux-ready":
+						issueApprovals.Experience = true
+					case "doc-ready":
+						issueApprovals.Documentation = true
+					case "px-ready":
+						issueApprovals.Support = true
+						//<-
 					}
 				}
 			}

--- a/jira/issue.go
+++ b/jira/issue.go
@@ -15,6 +15,7 @@ type IssueApprovals struct {
 	Quality       bool
 	Experience    bool
 	Documentation bool
+	Support       bool
 }
 
 // Issue represents a Jira Issue
@@ -127,7 +128,7 @@ func NewIssueCollection(size int) IssueCollection {
 
 // Approved returns true if all approvals are true
 func (a *IssueApprovals) Approved() bool {
-	return a.Development == true && a.Product == true && a.Quality == true && a.Experience == true && a.Documentation == true
+	return a.Development == true && a.Product == true && a.Quality == true && a.Experience == true && a.Documentation == true //&& a.Support == true
 }
 
 // IsActive returns true if the issue is currently worked on

--- a/jira/issue.go
+++ b/jira/issue.go
@@ -15,6 +15,7 @@ type IssueApprovals struct {
 	Quality       bool
 	Experience    bool
 	Documentation bool
+	Support       bool
 }
 
 // Issue represents a Jira Issue
@@ -128,6 +129,7 @@ func NewIssueCollection(size int) IssueCollection {
 // Approved returns true if all approvals are true
 func (a *IssueApprovals) Approved() bool {
 	return a.Development == true && a.Product == true && a.Quality == true && a.Experience == true && a.Documentation == true
+	//return a.Development == true && a.Product == true && a.Quality == true && a.Experience == true && a.Documentation == true && a.Support == true
 }
 
 // IsActive returns true if the issue is currently worked on

--- a/jira/issue.go
+++ b/jira/issue.go
@@ -129,7 +129,6 @@ func NewIssueCollection(size int) IssueCollection {
 // Approved returns true if all approvals are true
 func (a *IssueApprovals) Approved() bool {
 	return a.Development == true && a.Product == true && a.Quality == true && a.Experience == true && a.Documentation == true
-	//return a.Development == true && a.Product == true && a.Quality == true && a.Experience == true && a.Documentation == true && a.Support == true
 }
 
 // IsActive returns true if the issue is currently worked on


### PR DESCRIPTION
A recent change in our Jira instance broke the jiracsv tool that we use to update our gut check sheets. This update restores the tools ability to evaluate if epics are in "ready-ready" state.

The changes in Jira consisted of..
1. Renaming the "5-Acks Check" field to "Ready-Ready"
2. Changing the "check" items by replacing underscores with dashes. 

The following files were updated...
modified:   issue.go
modified:   client.go